### PR TITLE
CI セットアップ: Markdown lint と Dependabot を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     groups:
       github-actions:
         patterns:
           - "*"
+    labels:
+      - "dependencies"
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5

--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -1,0 +1,33 @@
+name: Markdown Lint
+
+# 対象リポジトリの .github/workflows/md-lint.yml として配置する caller workflow．
+# 以下 1 箇所のみ利用者が書き換える：
+#   - `OWNER` を利用する github-workflows のオーナー名に置き換える．
+#     （tomio2480 を直接利用するなら OWNER → tomio2480．自分でフォークした場合は自分のユーザー名）
+#
+# 参照先（@ 以降）の選び方：
+#   - `@main`     : 中央の最新ルール・辞書を常に適用する．既定．
+#   - `@v1`       : v1 系の latest．中央が明示的に移動した commit のみ追随（破壊的変更を避けたい場合）
+#   - `@v1.0.0`   : 不変．完全再現性が必要な場合
+#
+# 設定ファイル（.markdownlint-cli2.yaml / .textlintrc.json / prh.yml）は
+# 呼び出し側に存在すればそれが優先される．無ければ中央の標準設定が使われる．
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    uses: tomio2480/github-workflows/.github/workflows/markdown-lint.yml@main
+    # 必要に応じて inputs で上書き可能．詳細は中央リポジトリの README を参照．
+    # reusable workflow 側の既定は node-version "24"（Active LTS）．
+    # with:
+    #   node-version: "22"              # Maintenance LTS に下げる例
+    #   markdown-glob: "docs/**/*.md"   # 対象ディレクトリを絞る例
+    #   filter-mode: "nofilter"         # 既存ファイル全体を指摘したい場合

--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -6,12 +6,15 @@ name: Markdown Lint
 #     （tomio2480 を直接利用するなら OWNER → tomio2480．自分でフォークした場合は自分のユーザー名）
 #
 # 参照先（@ 以降）の選び方：
-#   - `@main`     : 中央の最新ルール・辞書を常に適用する．既定．
-#   - `@v1`       : v1 系の latest．中央が明示的に移動した commit のみ追随（破壊的変更を避けたい場合）
-#   - `@v1.0.0`   : 不変．完全再現性が必要な場合
+#   - 既定: `@<SHA> # v1` 形式で SHA pin とバージョンコメントを併記する．
+#     Dependabot が SHA とバージョンの両方を自動追随し，更新は PR で通知される．
+#     本リポジトリはこの方式を採用．
+#   - 代替 1: `@main` — 中央の最新ルール・辞書を即時反映．運用負荷ゼロだが Dependabot の
+#     更新検知は働かない．中央 repo の書き換えが即時反映される点に同意できる場合のみ．
+#   - 代替 2: `@<SHA> # v1.0.0` 形式 — 完全不変．パッチ追随も止めて固定したい場合．
 #
 # 設定ファイル（.markdownlint-cli2.yaml / .textlintrc.json / prh.yml）は
-# 呼び出し側に存在すればそれが優先される．無ければ中央の標準設定が使われる．
+# 呼び出し側に存在すればそれが優先される．無ければ参照先 commit の標準設定が使われる．
 
 on:
   pull_request:
@@ -24,7 +27,7 @@ permissions:
 
 jobs:
   lint:
-    uses: tomio2480/github-workflows/.github/workflows/markdown-lint.yml@main
+    uses: tomio2480/github-workflows/.github/workflows/markdown-lint.yml@e4e121c176567c46399f1f171a91605f1126f04c # v1
     # 必要に応じて inputs で上書き可能．詳細は中央リポジトリの README を参照．
     # reusable workflow 側の既定は node-version "24"（Active LTS）．
     # with:


### PR DESCRIPTION
## Summary

- `.github/workflows/md-lint.yml`: `tomio2480/github-workflows` の caller workflow を配置．参照は SHA pin ＋ バージョンコメント形式（ `@<SHA> # v1` ）で，Dependabot が SHA とバージョンの両方を自動追随する．PR で `.md` が変更されると reviewdog による Markdown Lint が走る．
- `.github/dependabot.yml`: `github-actions` エコシステムを daily で追跡．`groups` で更新 PR を 1 本に集約し，`labels: ["dependencies"]` で PR 管理を補助．

github-dev Skill の「初期セットアップの自動化導入」に従った最小構成．Ruby プロジェクトだが現状 Gemfile がないので `bundler` エコシステムは未登録．将来 gem を入れたタイミングで追加する想定．

## Test plan

- [ ] この PR で md-lint workflow が実行され，緑で通ること（ PR 内の `.md` がないので実質 no-op だが起動までは確認したい）
- [ ] Dependabot の設定が Settings → Security → Dependabot から読めること
- [ ] 以降の PR では `.md` を含むため md-lint の指摘が出ないこと

## セルフレビュー

- 差分: `.github/workflows/md-lint.yml`（ caller workflow のみ）と `.github/dependabot.yml`
- デバッグ残骸: なし
- コメントアウト: なし
- 依存追加: GitHub Actions のみ（コード依存は変化なし）
- セキュリティ: caller workflow は `tomio2480/github-workflows@<SHA> # v1` 形式で固定．Dependabot が SHA を追随する標準パターンに準拠．

## 再レビュー対応の経緯

gemini-code-assist のレビュー指摘（ groups 設定／ SHA pin ／末尾改行／ daily 間隔／ labels ）はすべて採用．`@main` から SHA pin への移行に伴い，[md-lint.yml](.github/workflows/md-lint.yml) 冒頭コメントの参照先選び方ガイドも新方針に刷新．

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係の自動スキャンを有効化し、毎日更新を確認するようにしました。
  * マークダウンファイルの品質検証ワークフローを導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->