### PR TITLE
docs: Phase 1 総括ノートと README に進捗表を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ PicoRuby + TEA5767 + Ruby.wasm で作る FM スペクトラムモニタ．函館
 [picoruby-tea5767-plan/README.md](picoruby-tea5767-plan/README.md) が v0.1 の正式な設計書．
 実装の進め方や決定の経緯は [docs/notes/](docs/notes/) のノート群を参照．
 
+## 実装の進捗
+
+表 1. v0.1 に向けた Phase ごとの進捗．
+
+| Phase | 内容 | 状態 | 関連 |
+|---|---|---|---|
+| 0 | 設計書 v0.1 ／ 函館局プリセット | 完了 | [#2](https://github.com/tomio2480/picoruby-tea5767/pull/2) |
+| 1 | web 純ロジック 4 本（ Aggregator / Protocol / PeakDetector / StationDirectory ） | 完了 | [#3](https://github.com/tomio2480/picoruby-tea5767/pull/3) ／ [Phase 1 総括](docs/notes/2026-05-01-phase1-summary.md) |
+| 2 | ブラウザ描画 ＋ モックソース結線 | 着手中 | [#4](https://github.com/tomio2480/picoruby-tea5767/pull/4) (Draft) |
+| 3 | Web Serial 接続 ＋ `Aggregator#clear` | 計画中 | [#6](https://github.com/tomio2480/picoruby-tea5767/pull/6) (Draft) |
+| 4 | firmware 3 本（ R2P2 想定） | 計画中 | [#5](https://github.com/tomio2480/picoruby-tea5767/pull/5) (Draft) |
+
 ## ライセンス
 
 MIT．[LICENSE](LICENSE) を参照．

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ PicoRuby + TEA5767 + Ruby.wasm で作る FM スペクトラムモニタ．函館
 
 | Phase | 内容 | 状態 | 関連 |
 |---|---|---|---|
-| 0 | 設計書 v0.1 ／ 函館局プリセット | 完了 | [#2](https://github.com/tomio2480/picoruby-tea5767/pull/2) |
-| 1 | web 純ロジック 4 本（ Aggregator / Protocol / PeakDetector / StationDirectory ） | 完了 | [#3](https://github.com/tomio2480/picoruby-tea5767/pull/3) ／ [Phase 1 総括](docs/notes/2026-05-01-phase1-summary.md) |
-| 2 | ブラウザ描画 ＋ モックソース結線 | 着手中 | [#4](https://github.com/tomio2480/picoruby-tea5767/pull/4) (Draft) |
-| 3 | Web Serial 接続 ＋ `Aggregator#clear` | 計画中 | [#6](https://github.com/tomio2480/picoruby-tea5767/pull/6) (Draft) |
-| 4 | firmware 3 本（ R2P2 想定） | 計画中 | [#5](https://github.com/tomio2480/picoruby-tea5767/pull/5) (Draft) |
+| 0 | 設計書 v0.1／函館局プリセット | 完了 | [#2](https://github.com/tomio2480/picoruby-tea5767/pull/2) |
+| 1 | web 純ロジック 4 本（Aggregator／Protocol／PeakDetector／StationDirectory） | 完了 | [#3](https://github.com/tomio2480/picoruby-tea5767/pull/3)／[Phase 1 総括](docs/notes/2026-05-01-phase1-summary.md) |
+| 2 | ブラウザ描画＋モックソース結線 | 着手中 | [#4](https://github.com/tomio2480/picoruby-tea5767/pull/4) (Draft) |
+| 3 | Web Serial 接続＋`Aggregator#clear` | 計画中 | [#6](https://github.com/tomio2480/picoruby-tea5767/pull/6) (Draft) |
+| 4 | firmware 3 本（R2P2 想定） | 計画中 | [#5](https://github.com/tomio2480/picoruby-tea5767/pull/5) (Draft) |
 
 ## ライセンス
 

--- a/docs/notes/2026-05-01-phase1-summary.md
+++ b/docs/notes/2026-05-01-phase1-summary.md
@@ -36,31 +36,31 @@ Phase 2 以降のブラウザ層・実機層から共通利用される基盤が
 
 | クラス | ファイル | 責務 |
 |---|---|---|
-| `Aggregator` | [web/lib/aggregator.rb](../../web/lib/aggregator.rb) | `channel_count` 個の RSSI を `pixel_count` 個の表示用配列へ集約．範囲外周波数は drop として記録 |
-| `Protocol` | [web/lib/protocol.rb](../../web/lib/protocol.rb) | TEA5767 firmware の JSON Lines を `{type, payload}` にパース．非文字列・不足フィールド・型不一致は `nil` |
-| `PeakDetector` | [web/lib/peak_detector.rb](../../web/lib/peak_detector.rb) | `pixels` 配列から閾値以上の極大点を抽出．ステートレス module |
-| `StationDirectory` | [web/lib/station_directory.rb](../../web/lib/station_directory.rb) | 函館 5 局のプリセットと周波数マッチ．Hz 単位で ± 50 kHz 境界を判定 |
+| `Aggregator` | [web/lib/aggregator.rb](../../web/lib/aggregator.rb) | `channel_count` 個の RSSI を `pixel_count` 個の表示用配列へ集約．範囲外周波数は drop として記録． |
+| `Protocol` | [web/lib/protocol.rb](../../web/lib/protocol.rb) | TEA5767 firmware の JSON Lines を `{type, payload}` にパース．非文字列・不足フィールド・型不一致は `nil`． |
+| `PeakDetector` | [web/lib/peak_detector.rb](../../web/lib/peak_detector.rb) | `pixels` 配列から閾値以上の極大点を抽出．ステートレス module． |
+| `StationDirectory` | [web/lib/station_directory.rb](../../web/lib/station_directory.rb) | 函館 5 局のプリセットと周波数マッチ．Hz 単位で ± 50 kHz 境界を判定． |
 
 ## 主要な技術判断
 
 詳細は [2026-04-23-phase1-tdd-findings.md](2026-04-23-phase1-tdd-findings.md) を参照．要点を抜粋する．
 
-- **「意図は結果で書く」原則の継承**: `freq_hz / 1_000` の切り捨て比較ではなく Hz 同士で直接比較する形へ修正．Phase 0 で確立した原則（[2026-04-29-phase0-closeout.md](2026-04-29-phase0-closeout.md)）の延長．
-- **Defensive Programming の取捨**: `Array#max` の `|| 0` フォールバックなど，事前ガードが効いていれば実行されない防御コードは可読性のために削除．
-- **`module_function` 採用基準**: ステートレスな純関数は `class` ではなく `module module_function` で表現し， KISS を優先．
-- **`fetch` と `dig` の使い分け**: 利用者の操作ミス（地域未登録）は `dig || []` で静かに扱い，データ構造の破損は `fetch` で Fail Fast．
-- **テストで日本語メソッド名を採用**: `def test_ピクセル数が...` で minitest がそのまま通る．意図が読み取りやすく，コメントを節約できる．
+- **「意図は結果で書く」原則の継承** ： `freq_hz / 1_000` の切り捨て比較ではなく Hz 同士で直接比較する形へ修正．Phase 0 で確立した原則（[2026-04-29-phase0-closeout.md](2026-04-29-phase0-closeout.md)）の延長．
+- **Defensive Programming の取捨** ： `Array#max` の `|| 0` フォールバックなど，事前ガードが効いていれば実行されない防御コードは可読性のために削除．
+- **`module_function` 採用基準** ：ステートレスな純関数は `class` ではなく `module module_function` で表現し， KISS を優先．
+- **`fetch` と `dig` の使い分け** ：利用者の操作ミス（地域未登録）は `dig || []` で静かに扱い，データ構造の破損は `fetch` で Fail Fast．
+- **テストで日本語メソッド名を採用** ： `def test_ピクセル数が...` で minitest がそのまま通る．意図が読み取りやすく，コメントを節約できる．
 
 ## レビュー対応で得た運用知見
 
 詳細は [2026-04-29-review-context-and-textlint-tips.md](2026-04-29-review-context-and-textlint-tips.md) を参照．Phase 1 で確定したカテゴリは次のとおり．
 
-- **gemini-code-assist の繰り返し誤指摘**: 4 種類． Node.js LTS バージョン認識， TEA5767 レジスタビット， PicoRuby `I2C#write` splat ， 全角括弧の内側スペース提案．
-  いずれも一次資料・中央規律で reject ．
-- **CodeRabbit の妥当な指摘採用例**: Aggregator 初期化引数の正整数バリデーション， Protocol 文字列ガード強化，テスト網羅追加．
-- **textlint の reject カテゴリ**: 表 caption ／固有名詞 ／ `prh` 誤 hit など．
+- **gemini-code-assist の繰り返し誤指摘** ： 4 種類．Node.js LTS バージョン認識，TEA5767 レジスタビット，PicoRuby `I2C#write` splat，全角括弧の内側スペース提案．
+  いずれも一次資料・中央規律で reject．
+- **CodeRabbit の妥当な指摘採用例** ： Aggregator 初期化引数の正整数バリデーション， Protocol 文字列ガード強化，テスト網羅追加．
+- **textlint の reject カテゴリ** ：表 caption／固有名詞／`prh` 誤 hit など．
   詳細は [tomio2480/github-workflows#12](https://github.com/tomio2480/github-workflows/issues/12) で根本対応中．
-- **textlint ローカル検証の運用**: `prh.yml` を CWD に一時配置して実行．
+- **textlint ローカル検証の運用** ： `prh.yml` を CWD に一時配置して実行．
   レビューに先回りして指摘を吸う．
 
 ## Phase 2 への申し送り

--- a/docs/notes/2026-05-01-phase1-summary.md
+++ b/docs/notes/2026-05-01-phase1-summary.md
@@ -1,0 +1,84 @@
+# Phase 1 総括: web 純ロジック 4 本の TDD 実装
+
+## 要約
+
+Phase 1 では `web/` 配下の純ロジック 4 本を minitest で TDD 実装した．
+対象クラスは `Aggregator`， `Protocol`， `PeakDetector`， `StationDirectory` の 4 つ．
+成果は PR #3 として main にマージ済み．
+Phase 2 以降のブラウザ層・実機層から共通利用される基盤が固まった．
+本ノートは既存ノート群の横断サマリで，登壇資料・対外発信のたたき台として位置づける．
+
+## 目次
+
+- 到達点
+- 実装したクラスの責務
+- 主要な技術判断
+- レビュー対応で得た運用知見
+- Phase 2 への申し送り
+- 参照
+
+## 到達点
+
+表 1. Phase 1 の到達点．
+
+| 項目 | 値 |
+|---|---|
+| 関連 PR | [#3](https://github.com/tomio2480/picoruby-tea5767/pull/3) |
+| マージコミット | `40896a02` |
+| ベースコミット | 5 コミット（クラス 4 本 + 初期コミット） |
+| レビュー対応コミット | 6 件（Aggregator drop 追跡・初期化ガード，Protocol 型検証・String ガード，StationDirectory Hz 単位比較ほか） |
+| テスト | 54 tests / 69 assertions（CRuby + minitest） |
+| Refactor サイクル | 0 回（Red → Green の 1 サイクルで KISS に収束） |
+
+## 実装したクラスの責務
+
+表 2. Phase 1 で実装した 4 本のクラスの責務．
+
+| クラス | ファイル | 責務 |
+|---|---|---|
+| `Aggregator` | [web/lib/aggregator.rb](../../web/lib/aggregator.rb) | `channel_count` 個の RSSI を `pixel_count` 個の表示用配列へ集約．範囲外周波数は drop として記録 |
+| `Protocol` | [web/lib/protocol.rb](../../web/lib/protocol.rb) | TEA5767 firmware の JSON Lines を `{type, payload}` にパース．非文字列・不足フィールド・型不一致は `nil` |
+| `PeakDetector` | [web/lib/peak_detector.rb](../../web/lib/peak_detector.rb) | `pixels` 配列から閾値以上の極大点を抽出．ステートレス module |
+| `StationDirectory` | [web/lib/station_directory.rb](../../web/lib/station_directory.rb) | 函館 5 局のプリセットと周波数マッチ．Hz 単位で ± 50 kHz 境界を判定 |
+
+## 主要な技術判断
+
+詳細は [2026-04-23-phase1-tdd-findings.md](2026-04-23-phase1-tdd-findings.md) を参照．要点を抜粋する．
+
+- **「意図は結果で書く」原則の継承**: `freq_hz / 1_000` の切り捨て比較ではなく Hz 同士で直接比較する形へ修正．Phase 0 で確立した原則（[2026-04-29-phase0-closeout.md](2026-04-29-phase0-closeout.md)）の延長．
+- **Defensive Programming の取捨**: `Array#max` の `|| 0` フォールバックなど，事前ガードが効いていれば実行されない防御コードは可読性のために削除．
+- **`module_function` 採用基準**: ステートレスな純関数は `class` ではなく `module module_function` で表現し， KISS を優先．
+- **`fetch` と `dig` の使い分け**: 利用者の操作ミス（地域未登録）は `dig || []` で静かに扱い，データ構造の破損は `fetch` で Fail Fast．
+- **テストで日本語メソッド名を採用**: `def test_ピクセル数が...` で minitest がそのまま通る．意図が読み取りやすく，コメントを節約できる．
+
+## レビュー対応で得た運用知見
+
+詳細は [2026-04-29-review-context-and-textlint-tips.md](2026-04-29-review-context-and-textlint-tips.md) を参照．Phase 1 で確定したカテゴリは次のとおり．
+
+- **gemini-code-assist の繰り返し誤指摘**: 4 種類． Node.js LTS バージョン認識， TEA5767 レジスタビット， PicoRuby `I2C#write` splat ， 全角括弧の内側スペース提案．
+  いずれも一次資料・中央規律で reject ．
+- **CodeRabbit の妥当な指摘採用例**: Aggregator 初期化引数の正整数バリデーション， Protocol 文字列ガード強化，テスト網羅追加．
+- **textlint の reject カテゴリ**: 表 caption ／固有名詞 ／ `prh` 誤 hit など．
+  詳細は [tomio2480/github-workflows#12](https://github.com/tomio2480/github-workflows/issues/12) で根本対応中．
+- **textlint ローカル検証の運用**: `prh.yml` を CWD に一時配置して実行．
+  レビューに先回りして指摘を吸う．
+
+## Phase 2 への申し送り
+
+- `mock_source.rb` を **tick 生成のロジック層** と **`setTimeout` で流す時間軸層** に分離する．ロジック層は CRuby + minitest で TDD 可能な状態に保つ．
+- `Aggregator#update(channel_index, frequency_hz, rssi)` の 3 引数シグネチャを維持．
+  Phase 2 の MockStream と Phase 3 の SerialClient で共通利用する．
+- `Aggregator#clear` は Phase 3 で追加（連続スキャンの tick `i==0` 受信時にリセット）．Phase 2 の単発スキャンでは不要．
+- `stations.json` 肥大化時に備えて統合テスト（実 JSON で `StationDirectory` が破綻しないか）を Phase 4 までに検討．
+
+## 参照
+
+- 関連 PR: [picoruby-tea5767#3](https://github.com/tomio2480/picoruby-tea5767/pull/3)
+- 既存ノート
+  - [2026-04-23-implementation-plan.md](2026-04-23-implementation-plan.md)
+  - [2026-04-23-display-architecture.md](2026-04-23-display-architecture.md)
+  - [2026-04-23-phase1-tdd-findings.md](2026-04-23-phase1-tdd-findings.md)
+  - [2026-04-29-phase0-closeout.md](2026-04-29-phase0-closeout.md)
+  - [2026-04-29-review-context-and-textlint-tips.md](2026-04-29-review-context-and-textlint-tips.md)
+- 設計書: [picoruby-tea5767-plan/README.md](../../picoruby-tea5767-plan/README.md)
+- 実装: [web/lib/](../../web/lib/) / [web/spec/](../../web/spec/) / [web/Rakefile](../../web/Rakefile)


### PR DESCRIPTION
## Summary

- Phase 1（PR #3 マージ済み）の総括として `docs/notes/2026-05-01-phase1-summary.md` を新規作成．既存 4 ノート（implementation-plan / display-architecture / phase1-tdd-findings / phase0-closeout）の横断サマリで，登壇資料・対外発信のたたき台として位置づける．
- README に「実装の進捗」節と Phase 0〜4 の進捗テーブルを追加．外部訪問者が一覧で現状を把握できるようにする．

## 背景

PR #3 のマージで Phase 1 が完了し，グローバル CLAUDE.md「マージ後のフォロー」原則（README と実装の整合確認）に従う．Phase 1 で得た知見は既存ノートに分散しているため， **横断サマリ** を 1 本立てておくことで Phase 2 以降の参照と登壇資料化を容易にする．

## 含まれる変更

- `README.md` (+14 行) — 「実装の進捗」節を追加．表 1 に Phase 0〜4 の進捗を一覧
- `docs/notes/2026-05-01-phase1-summary.md` (+84 行 新規) — 要約・目次・到達点（表 1）・実装したクラス（表 2）・主要技術判断・レビュー対応知見・Phase 2 申し送り・参照

## 既知の textlint 違反

- `JSON Lines` 内の `JS` substring が中央 prh `JS => JavaScript` パターンに誤マッチする件 3 件（`README.md` L7， `phase1-summary.md` L38, L70）．
- これは既知の reject カテゴリで， `tomio2480/github-workflows#12` で根本対応中．reviewdog で指摘されたら個別に reject 返信する．

## Test plan

- [x] ローカル textlint で追記分の sentence-length / max-kanji / 全角括弧スペースは違反なし
- [x] 相対パスリンクの実在を self-reviewer で確認
- [x] README 既存セクション（特徴・ディレクトリ構成・詳細・ライセンス）の破壊なし
- [x] 表 caption と表番号の整合（表 1, 表 2 が連番）

## Self review

push 直前にセルフレビュー実施済み（self-reviewer エージェントで一次走査）．
medium 指摘 1 件（到達点テーブルの caption 欠如）と low 指摘 1 件（README 末尾改行）は本 PR 内で修正済み．

🤖 Generated with [Claude Code](https://claude.com/claude-code)