### PR TITLE
chore(workflow): バージョンコメントを v2.2.2 に揃える

### DIFF
--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -40,8 +40,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Markdown Lint via composite action
-        # github-workflows v2（composite action）への参照．SHA は v2 タグが指す merge commit．
-        uses: tomio2480/github-workflows/.github/actions/markdown-lint@b69f79d8ec105c0335cc88be8f3b1c236d02d96f # v2
+        # github-workflows v2.2.2（composite action）への参照．SHA は v2.2.2 タグが指す merge commit．
+        uses: tomio2480/github-workflows/.github/actions/markdown-lint@b69f79d8ec105c0335cc88be8f3b1c236d02d96f # v2.2.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # 必要に応じて inputs で上書き可能．詳細は中央リポジトリの README を参照．


### PR DESCRIPTION
## Summary

- Dependabot PR #14 で SHA は v2.2.2 の merge commit に更新済みだが， comment が `# v2` のままだったため `# v2.2.2` に揃える．
- step 直前の説明コメントも v2.2.2 への参照に書き直す．

## 背景

Dependabot は SHA は自動追随するが，バージョン comment は更新しない仕様．タグリリース時に手動で comment を追従させる必要があるため，本 PR で対応する．

## 変更ファイル

- `.github/workflows/md-lint.yml` （ 2 行）

## Test plan

- [x] grep で `# v2` の残存箇所を確認
- [x] L13 / L16 は説明文（一般形・代替例）なので変更対象外と判断
- [x] L42-44 のみ実体の参照なので修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub ワークフローの Markdown Lint ステップの内部ドキュメンテーションを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->