### PR TITLE
chore(workflow): markdown-lint を v2.2.2 → v2.3.0 に更新

### DIFF
--- a/.github/workflows/md-lint.yml
+++ b/.github/workflows/md-lint.yml
@@ -40,8 +40,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Markdown Lint via composite action
-        # github-workflows v2.2.2（composite action）への参照．SHA は v2.2.2 タグが指す merge commit．
-        uses: tomio2480/github-workflows/.github/actions/markdown-lint@b69f79d8ec105c0335cc88be8f3b1c236d02d96f # v2.2.2
+        # github-workflows v2.3.0（composite action）への参照．SHA は v2.3.0 タグが指す merge commit．
+        uses: tomio2480/github-workflows/.github/actions/markdown-lint@185a9045a87bafb667de89339b3fba24044a1cdc # v2.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # 必要に応じて inputs で上書き可能．詳細は中央リポジトリの README を参照．


### PR DESCRIPTION
## Summary

- `tomio2480/github-workflows` が v2.3.0 をリリース．markdown-lint composite action の参照 SHA を v2.3.0 タグの merge commit (`185a9045`) に更新し， comment も `# v2.3.0` に揃える．

## リリース内容

[v2.3.0 — reviewdog 指摘ゼロでも summary コメントを upsert する](https://github.com/tomio2480/github-workflows/releases/tag/v2.3.0)

レビュー対応で push したあと「指摘なし」が明示的に表示されるようになる挙動変更．本リポジトリへの実害なし．

## 変更ファイル

- `.github/workflows/md-lint.yml` （2 行）

## Test plan

- [x] v2.3.0 タグの SHA を `gh api` で確認
- [x] comment と SHA の整合性を確認
- [ ] 本 PR の Markdown Lint チェックで v2.3.0 動作を確認（push 後 CI で自動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)