### PR TITLE
data: 旭川・札幌・東京（23 区）の FM 局プリセットデータを追加（#13）

### DIFF
--- a/web/data/stations.json
+++ b/web/data/stations.json
@@ -160,7 +160,7 @@
         },
         {
           "freq_khz": 89700,
-          "name": "InterFM897",
+          "name": "interfm",
           "kind": "fm",
           "power_w": 10000,
           "site": "東京タワー（港区）",

--- a/web/data/stations.json
+++ b/web/data/stations.json
@@ -6,7 +6,7 @@
       "stations": [
         {
           "freq_khz": 79400,
-          "name": "FM NORTHWAVE",
+          "name": "FM NORTH WAVE",
           "kind": "fm",
           "power_w": 250,
           "site": "函館",
@@ -43,6 +43,152 @@
           "power_w": 250,
           "site": "函館",
           "note": "FM 北海道 函館中継局"
+        }
+      ]
+    },
+    "asahikawa": {
+      "name": "旭川市",
+      "prefecture": "北海道",
+      "stations": [
+        {
+          "freq_khz": 76400,
+          "name": "AIR-G'（FM 北海道）",
+          "kind": "fm",
+          "power_w": 500,
+          "site": "旭川（旭山）",
+          "note": "FM 北海道 旭川局"
+        },
+        {
+          "freq_khz": 79800,
+          "name": "FM NORTH WAVE",
+          "kind": "fm",
+          "power_w": 500,
+          "site": "旭川（旭山）",
+          "note": "FM ノースウェーブ 旭川局"
+        },
+        {
+          "freq_khz": 83700,
+          "name": "FMりべーる",
+          "kind": "community",
+          "power_w": 20,
+          "site": "旭川",
+          "note": "JOZZ1AB-FM"
+        },
+        {
+          "freq_khz": 85800,
+          "name": "NHK-FM 旭川",
+          "kind": "fm",
+          "power_w": 500,
+          "site": "旭川（旭山）",
+          "note": "NHK-FM 旭川局"
+        }
+      ]
+    },
+    "sapporo": {
+      "name": "札幌市",
+      "prefecture": "北海道",
+      "stations": [
+        {
+          "freq_khz": 80400,
+          "name": "AIR-G'（FM 北海道）",
+          "kind": "fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "FM 北海道 札幌局"
+        },
+        {
+          "freq_khz": 82500,
+          "name": "FM NORTH WAVE",
+          "kind": "fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "FM ノースウェーブ 札幌局"
+        },
+        {
+          "freq_khz": 85200,
+          "name": "NHK-FM 札幌",
+          "kind": "fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "JOAS-FM"
+        },
+        {
+          "freq_khz": 90400,
+          "name": "STV ラジオ（ワイドFM）",
+          "kind": "wide_fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "STV ラジオ FM 補完放送"
+        },
+        {
+          "freq_khz": 91500,
+          "name": "HBC ラジオ（ワイドFM）",
+          "kind": "wide_fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "HBC ラジオ FM 補完放送"
+        }
+      ]
+    },
+    "tokyo": {
+      "name": "東京（23 区）",
+      "prefecture": "東京都",
+      "stations": [
+        {
+          "freq_khz": 80000,
+          "name": "TOKYO FM",
+          "kind": "fm",
+          "power_w": 10000,
+          "site": "東京タワー（港区）",
+          "note": "JOAU-FM"
+        },
+        {
+          "freq_khz": 81300,
+          "name": "J-WAVE",
+          "kind": "fm",
+          "power_w": 7000,
+          "site": "東京スカイツリー（墨田区）",
+          "note": "JOAV-FM"
+        },
+        {
+          "freq_khz": 82500,
+          "name": "NHK-FM 東京",
+          "kind": "fm",
+          "power_w": 7000,
+          "site": "東京スカイツリー（墨田区）",
+          "note": "JOAK-FM"
+        },
+        {
+          "freq_khz": 89700,
+          "name": "InterFM897",
+          "kind": "fm",
+          "power_w": 10000,
+          "site": "東京タワー（港区）",
+          "note": "JODW-FM"
+        },
+        {
+          "freq_khz": 90500,
+          "name": "TBS ラジオ（ワイドFM）",
+          "kind": "wide_fm",
+          "power_w": 7000,
+          "site": "東京スカイツリー（墨田区）",
+          "note": "TBS ラジオ FM 補完放送"
+        },
+        {
+          "freq_khz": 91600,
+          "name": "文化放送（ワイドFM）",
+          "kind": "wide_fm",
+          "power_w": 7000,
+          "site": "東京スカイツリー（墨田区）",
+          "note": "文化放送 FM 補完放送"
+        },
+        {
+          "freq_khz": 93000,
+          "name": "ニッポン放送（ワイドFM）",
+          "kind": "wide_fm",
+          "power_w": 7000,
+          "site": "東京スカイツリー（墨田区）",
+          "note": "ニッポン放送 FM 補完放送"
         }
       ]
     }

--- a/web/index.html
+++ b/web/index.html
@@ -20,6 +20,9 @@
         地域:
         <select id="region">
           <option value="hakodate">函館市</option>
+          <option value="asahikawa">旭川市</option>
+          <option value="sapporo">札幌市</option>
+          <option value="tokyo">東京（23 区）</option>
         </select>
       </label>
       <button type="button" id="start-mock">モックスキャン開始</button>

--- a/web/spec/station_directory_test.rb
+++ b/web/spec/station_directory_test.rb
@@ -1,4 +1,5 @@
 require "minitest/autorun"
+require "json"
 require_relative "../lib/station_directory"
 
 class StationDirectoryTest < Minitest::Test
@@ -68,5 +69,30 @@ class StationDirectoryTest < Minitest::Test
   def test_存在しない地域のlookupはnil
     dir = StationDirectory.new(FIXTURE)
     assert_nil dir.lookup("sapporo", 80_700_000)
+  end
+end
+
+class StationDirectoryDataTest < Minitest::Test
+  STATIONS_DATA = JSON.parse(
+    File.read(File.join(__dir__, "../data/stations.json"))
+  ).freeze
+  FREQ_MIN_KHZ = 76_000
+  FREQ_MAX_KHZ = 95_000
+
+  %w[asahikawa sapporo tokyo].each do |region|
+    define_method(:"test_#{region}_は空でない局リストを返す") do
+      dir = StationDirectory.new(STATIONS_DATA)
+      assert_operator dir.stations(region).size, :>, 0
+    end
+
+    define_method(:"test_#{region}_の全周波数はスキャン範囲内") do
+      dir = StationDirectory.new(STATIONS_DATA)
+      dir.stations(region).each do |s|
+        assert_operator s["freq_khz"], :>=, FREQ_MIN_KHZ,
+          "#{s["name"]} の #{s["freq_khz"]} kHz が下限を下回っている"
+        assert_operator s["freq_khz"], :<=, FREQ_MAX_KHZ,
+          "#{s["name"]} の #{s["freq_khz"]} kHz が上限を超えている"
+      end
+    end
   end
 end

--- a/web/spec/station_directory_test.rb
+++ b/web/spec/station_directory_test.rb
@@ -79,7 +79,7 @@ class StationDirectoryDataTest < Minitest::Test
   FREQ_MIN_KHZ = 76_000
   FREQ_MAX_KHZ = 95_000
 
-  %w[asahikawa sapporo tokyo].each do |region|
+  STATIONS_DATA["regions"].keys.each do |region|
     define_method(:"test_#{region}_は空でない局リストを返す") do
       dir = StationDirectory.new(STATIONS_DATA)
       assert_operator dir.stations(region).size, :>, 0


### PR DESCRIPTION
## セルフレビュー実施済み

self-reviewer エージェントによる走査で high の懸念なしを確認した．
medium 指摘（表記揺れ・TDD コミット分割・require 配置）はすべて対応済み．

## 概要

Issue #13 対応．`web/data/stations.json` に旭川・札幌・東京（23 区）の FM 局データを追加し，地域プルダウンに対応 option を追加する．

## 変更内容

### 追加局（計 16 局）

| 地域 | 局数 | 主な局種別 |
|---|---|---|
| 旭川市（asahikawa） | 4 | 広域 FM・コミュニティ FM |
| 札幌市（sapporo） | 5 | 広域 FM・ワイドFM |
| 東京（23 区）（tokyo） | 7 | 広域 FM・ワイドFM |

- `kind` 値に `wide_fm` を新規追加（FM 補完放送 = ワイドFM 専用）
- 函館データの `"FM NORTHWAVE"` を公式表記 `"FM NORTH WAVE"` に統一

### データソース

- AIR-G' 公式サイト（送信局一覧）
- FM NORTH WAVE 公式サイト
- FMりべーる公式サイト
- 総務省 ワイドFM 局一覧（FM 補完放送周波数・出力）
- Wikipedia FM 補完中継局（送信出力）
- 検索結果（NHK-FM 各局周波数・出力）

### TDD

1. テスト追加（Red）: 新地域の局リストが非空 + 全周波数がスキャン範囲内
2. データ追加（Green）: 全 16 テスト・81 アサーション通過

## 受け入れ基準の確認

- [x] 追加地域の `stations(region_key)` が非空配列を返す
- [x] 全周波数が 76000〜95000 kHz の範囲内
- [x] 既存テストが緑のまま（16 runs, 81 assertions, 0 failures）
- [x] `<select id="region">` に 3 件の `<option>` を追加

## スコープ外（別 PR で対応可能）

- 札幌・東京のコミュニティ FM 局（多数あり，別途データ調査が必要）
- 札幌の大通補完局（低出力のため受信可能距離が限定的）

🤖 Generated with [Claude Code](https://claude.com/claude-code)