### PR TITLE
feat: 初期化完了時に GP25 内蔵 LED を点灯させる

### DIFF
--- a/firmware/app.rb
+++ b/firmware/app.rb
@@ -4,6 +4,8 @@
 # CRuby テストの対象外（I2C / sleep_ms などハードウェア API に依存）．
 #
 # 確定済みの PicoRuby / R2P2 API:
+#   - GPIO.new(pin, GPIO::OUT) ... picoruby-gpio
+#   - led.write(1) / led.write(0) ... HIGH / LOW 出力
 #   - I2C.new(unit: :RP2040_I2C0, sda_pin:, scl_pin:, frequency:) ... picoruby-i2c
 #   - i2c.write(addr, b1, b2, ..., bN) ... 可変長引数
 #   - i2c.read(addr, n) ... バイト列 String を返す．呼び出し側で .bytes して Array[Integer] 化
@@ -13,6 +15,7 @@
 # 注意: この R2P2 ビルドでは rescue（修飾子・begin/rescue/end ともに）は未サポート．
 #       Unimplemented opcode (0x56) が発生するため使用禁止．
 
+require "gpio"
 require "i2c"
 require "/home/lib/tea5767"
 require "/home/lib/spectrum_scanner"
@@ -23,6 +26,7 @@ STEP_HZ       = 100_000
 CHANNEL_COUNT = 191
 IDLE_MS       = 500
 
+led      = GPIO.new(25, GPIO::OUT)
 i2c      = I2C.new(unit: :RP2040_I2C0, sda_pin: 4, scl_pin: 5, frequency: 100_000)
 receiver = TEA5767.new(i2c)
 emitter  = SerialEmitter.new($stdout)
@@ -33,6 +37,7 @@ scanner  = SpectrumScanner.new(
   CHANNEL_COUNT,
   TEA5767::PLL_LOCK_WAIT_MS
 )
+led.write(1)
 
 loop do
   peak_index = 0

--- a/firmware/app.rb
+++ b/firmware/app.rb
@@ -21,12 +21,13 @@ require "/home/lib/tea5767"
 require "/home/lib/spectrum_scanner"
 require "/home/lib/serial_emitter"
 
+LED_PIN       = 25
 START_HZ      = 76_000_000
 STEP_HZ       = 100_000
 CHANNEL_COUNT = 191
 IDLE_MS       = 500
 
-led      = GPIO.new(25, GPIO::OUT)
+led      = GPIO.new(LED_PIN, GPIO::OUT)
 i2c      = I2C.new(unit: :RP2040_I2C0, sda_pin: 4, scl_pin: 5, frequency: 100_000)
 receiver = TEA5767.new(i2c)
 emitter  = SerialEmitter.new($stdout)


### PR DESCRIPTION
## Summary

- `firmware/app.rb` に GP25 内蔵 LED 制御を追加
- 全コンポーネント初期化完了後に `led.write(1)` を呼び出し，Pico が「準備完了」を視覚で示せるようにする
- `require "gpio"` および `GPIO.new(25, GPIO::OUT)` を採用

## PicoRuby VM 制約への対応

PicoRuby R2P2 3.4.2 の既知制約を回避した設計:

| 制約 | 対応 |
|---|---|
| `rescue` 使用不可 | 例外処理なし（エラーは REPL に落とす） |
| lambda リテラル動的生成不可 | 変数・引数に lambda を使わない |
| 位置 + キーワード引数混在不可 | `GPIO.new(25, GPIO::OUT)` は位置引数のみ |

## Test plan

- [ ] Pico 実機に `/home/app.rb` として配置して動作確認
- [ ] ブート完了後に GP25 LED が点灯することを目視確認
- [ ] WebSerial から JSON データが引き続き正常に受信できることを確認

## 関連

- Closes #26 (Task 1: LED フィードバックを app.rb に組み込む)
- 制約の詳細: `docs/notes/2026-05-13-picoruby-vm-limitations.md`

セルフレビュー実施済み（VM 制約違反・セキュリティ上の問題なし）．

Generated with [Claude Code](https://claude.com/claude-code)