### PR TITLE
feat: スキャン後のグラフバークリックで受信周波数を固定する

### DIFF
--- a/firmware/app.rb
+++ b/firmware/app.rb
@@ -44,24 +44,35 @@ led.write(0)   # 初期化完了の瞬間点灯後，コマンド待ち状態に
 loop do
   line = $stdin.gets
   next if line.nil?   # nil になる条件は未確定（CDC 切断時等）．rescue 禁止のため next で継続する
-  next unless line.strip == "SCAN"   # コマンド名は web/app.rb の write("SCAN\n") と対応
+  cmd   = line.strip
+  parts = cmd.split(":")
 
-  led.write(1)
-  peak_index = 0
-  peak_rssi  = -1
+  case parts[0]
+  when "SCAN"
+    led.write(1)
+    peak_index = 0
+    peak_rssi  = -1
 
-  scanner.scan do |i, freq, status|
-    emitter.tick(i: i, f: freq, rssi: status[:rssi], stereo: status[:stereo])
-    if status[:rssi] > peak_rssi
-      peak_rssi  = status[:rssi]
-      peak_index = i
+    scanner.scan do |i, freq, status|
+      emitter.tick(i: i, f: freq, rssi: status[:rssi], stereo: status[:stereo])
+      if status[:rssi] > peak_rssi
+        peak_rssi  = status[:rssi]
+        peak_index = i
+      end
     end
-  end
 
-  emitter.done(peak: {
-    "i"    => peak_index,
-    "f"    => START_HZ + STEP_HZ * peak_index,
-    "rssi" => peak_rssi,
-  })
-  led.write(0)
+    emitter.done(peak: {
+      "i"    => peak_index,
+      "f"    => START_HZ + STEP_HZ * peak_index,
+      "rssi" => peak_rssi,
+    })
+    led.write(0)
+  when "TUNE"
+    next if parts[1].nil?
+    freq_hz = parts[1].to_i
+    next if freq_hz < START_HZ || freq_hz > START_HZ + STEP_HZ * (CHANNEL_COUNT - 1)
+    receiver.tune(freq_hz)
+    led.write(1)
+    led.write(0)
+  end
 end

--- a/firmware/app.rb
+++ b/firmware/app.rb
@@ -73,6 +73,7 @@ loop do
     next if freq_hz < START_HZ || freq_hz > START_HZ + STEP_HZ * (CHANNEL_COUNT - 1)
     receiver.tune(freq_hz)
     led.write(1)
+    sleep_ms(50)
     led.write(0)
   end
 end

--- a/web/app.rb
+++ b/web/app.rb
@@ -228,7 +228,7 @@ if directory
 
   canvas.addEventListener("click") do |event|
     next if is_scanning
-    next if last_rssi_array.nil?
+    next if last_rssi_array.nil? || last_named_labels.nil?
 
     rect     = canvas.call(:getBoundingClientRect)
     scale    = canvas[:width].to_f / rect[:width].to_f
@@ -243,7 +243,8 @@ if directory
     renderer.draw_bars(last_rssi_array, ch_index)
     renderer.draw_station_labels(last_named_labels)
 
-    scan_status_el[:textContent] = "選局: #{mhz_str} MHz"
+    label = last_named_labels.find { |l| l[:ch_index] == ch_index }
+    scan_status_el[:textContent] = "選局: #{mhz_str} MHz#{label ? " - #{label[:name]}" : ""}"
     pico_client&.write("TUNE:#{freq_hz}\n")
   end
 end

--- a/web/app.rb
+++ b/web/app.rb
@@ -49,6 +49,10 @@ if directory
   status_el[:textContent] = "Ruby.wasm 起動成功: Ruby #{RUBY_VERSION}"
   status_el[:className]   = "status ok"
 
+  is_scanning       = false
+  last_rssi_array   = nil
+  last_named_labels = nil
+
   finalize_scan = lambda do |aggregator, region_key|
     rssi_array = aggregator.pixels
     peaks = PeakDetector.detect(rssi_array, threshold: PEAK_THRESHOLD)
@@ -67,9 +71,9 @@ if directory
     renderer.clear
     renderer.draw_axis
     renderer.draw_bars(rssi_array)
-    renderer.draw_station_labels(
-      named.map { |p| { ch_index: p[:ch_index], name: p[:name] } }
-    )
+    last_rssi_array   = rssi_array
+    last_named_labels = named.map { |p| { ch_index: p[:ch_index], name: p[:name] } }
+    renderer.draw_station_labels(last_named_labels)
 
     rows = named.sort_by { |p| -p[:rssi] }.map do |p|
       mhz = format("%.1f", p[:freq_hz] / 1_000_000.0)
@@ -118,6 +122,7 @@ if directory
     region_key = region_select_el[:value].to_s
     station_freqs_khz = directory.stations(region_key).map { |s| s["freq_khz"] }
 
+    is_scanning                  = true
     scan_status_el[:textContent] = "モックスキャン中..."
     peak_tbody_el[:innerHTML]    = "<tr><td colspan=\"3\">スキャン中...</td></tr>"
 
@@ -132,14 +137,16 @@ if directory
     stream = MockStream.new(source, start_hz: START_HZ, step_hz: STEP_HZ)
 
     on_finish = lambda do
-      start_mock_btn[:disabled]   = false
-      connect_pico_btn[:disabled] = false
+      is_scanning                  = false
+      start_mock_btn[:disabled]    = false
+      connect_pico_btn[:disabled]  = false
     end
     stream.run(&make_handler.call(aggregator, region_key, on_finish))
   rescue => e
     scan_status_el[:textContent] = "スキャン準備エラー: #{e.message}"
-    start_mock_btn[:disabled]   = false
-    connect_pico_btn[:disabled] = false
+    is_scanning                  = false
+    start_mock_btn[:disabled]    = false
+    connect_pico_btn[:disabled]  = false
   end
 
   connect_pico_btn.addEventListener("click") do
@@ -196,6 +203,7 @@ if directory
     next if scan_pico_btn[:disabled].to_s == "true"
     next if pico_client.nil?
 
+    is_scanning                  = true
     scan_pico_btn[:disabled]     = true
     scan_status_el[:textContent] = "スキャン中..."
     peak_tbody_el[:innerHTML]    = "<tr><td colspan=\"3\">スキャン中...</td></tr>"
@@ -204,6 +212,7 @@ if directory
     aggregator = Aggregator.new(channel_count: CHANNEL_COUNT, pixel_count: CHANNEL_COUNT)
 
     on_scan_done = lambda do
+      is_scanning              = false
       scan_pico_btn[:disabled] = false
       current_handler          = nil
     end
@@ -212,7 +221,29 @@ if directory
     pico_client.write("SCAN\n")   # コマンド名は firmware/app.rb の line.strip == "SCAN" と対応
   rescue => e
     scan_status_el[:textContent] = "スキャン準備エラー: #{e.message}"
+    is_scanning                  = false
     scan_pico_btn[:disabled]     = false
     current_handler              = nil
+  end
+
+  canvas.addEventListener("click") do |event|
+    next if is_scanning
+    next if last_rssi_array.nil?
+
+    rect     = canvas.call(:getBoundingClientRect)
+    scale    = canvas[:width].to_f / rect[:width].to_f
+    canvas_x = (event[:clientX].to_f - rect[:left].to_f) * scale
+    ch_index = renderer.x_to_ch_index(canvas_x)
+
+    freq_hz = START_HZ + STEP_HZ * ch_index
+    mhz_str = format("%.1f", freq_hz / 1_000_000.0)
+
+    renderer.clear
+    renderer.draw_axis
+    renderer.draw_bars(last_rssi_array, ch_index)
+    renderer.draw_station_labels(last_named_labels)
+
+    scan_status_el[:textContent] = "選局: #{mhz_str} MHz"
+    pico_client&.write("TUNE:#{freq_hz}\n")
   end
 end

--- a/web/app.rb
+++ b/web/app.rb
@@ -49,9 +49,11 @@ if directory
   status_el[:textContent] = "Ruby.wasm 起動成功: Ruby #{RUBY_VERSION}"
   status_el[:className]   = "status ok"
 
-  is_scanning       = false
-  last_rssi_array   = nil
-  last_named_labels = nil
+  is_scanning        = false
+  last_rssi_array    = nil
+  last_named_labels  = nil
+  selected_ch_index  = nil
+  last_hover_ch      = nil
 
   finalize_scan = lambda do |aggregator, region_key|
     rssi_array = aggregator.pixels
@@ -68,6 +70,8 @@ if directory
       }
     end
 
+    selected_ch_index = nil
+    last_hover_ch     = nil
     renderer.clear
     renderer.draw_axis
     renderer.draw_bars(rssi_array)
@@ -235,16 +239,46 @@ if directory
     canvas_x = (event[:clientX].to_f - rect[:left].to_f) * scale
     ch_index = renderer.x_to_ch_index(canvas_x)
 
+    selected_ch_index = ch_index
     freq_hz = START_HZ + STEP_HZ * ch_index
     mhz_str = format("%.1f", freq_hz / 1_000_000.0)
 
     renderer.clear
     renderer.draw_axis
-    renderer.draw_bars(last_rssi_array, ch_index)
+    renderer.draw_bars(last_rssi_array, selected_ch_index)
     renderer.draw_station_labels(last_named_labels)
 
     label = last_named_labels.find { |l| l[:ch_index] == ch_index }
     scan_status_el[:textContent] = "選局: #{mhz_str} MHz#{label ? " - #{label[:name]}" : ""}"
     pico_client&.write("TUNE:#{freq_hz}\n")
+  end
+
+  canvas.addEventListener("mousemove") do |event|
+    next if is_scanning
+    next if last_rssi_array.nil? || last_named_labels.nil?
+
+    rect     = canvas.call(:getBoundingClientRect)
+    scale    = canvas[:width].to_f / rect[:width].to_f
+    canvas_x = (event[:clientX].to_f - rect[:left].to_f) * scale
+    hover_ch = renderer.x_to_ch_index(canvas_x)
+
+    next if hover_ch == last_hover_ch
+
+    last_hover_ch = hover_ch
+    renderer.clear
+    renderer.draw_axis
+    renderer.draw_bars(last_rssi_array, selected_ch_index, hover_ch)
+    renderer.draw_station_labels(last_named_labels)
+  end
+
+  canvas.addEventListener("mouseleave") do |_event|
+    next if is_scanning
+    next if last_rssi_array.nil? || last_named_labels.nil?
+
+    last_hover_ch = nil
+    renderer.clear
+    renderer.draw_axis
+    renderer.draw_bars(last_rssi_array, selected_ch_index)
+    renderer.draw_station_labels(last_named_labels)
   end
 end

--- a/web/app.rb
+++ b/web/app.rb
@@ -230,6 +230,13 @@ if directory
     current_handler              = nil
   end
 
+  refresh_canvas = lambda do
+    renderer.clear
+    renderer.draw_axis
+    renderer.draw_bars(last_rssi_array, selected_ch_index, last_hover_ch)
+    renderer.draw_station_labels(last_named_labels)
+  end
+
   canvas.addEventListener("click") do |event|
     next if is_scanning
     next if last_rssi_array.nil? || last_named_labels.nil?
@@ -240,15 +247,11 @@ if directory
     ch_index = renderer.x_to_ch_index(canvas_x)
 
     selected_ch_index = ch_index
+    refresh_canvas.call
+
     freq_hz = START_HZ + STEP_HZ * ch_index
     mhz_str = format("%.1f", freq_hz / 1_000_000.0)
-
-    renderer.clear
-    renderer.draw_axis
-    renderer.draw_bars(last_rssi_array, selected_ch_index)
-    renderer.draw_station_labels(last_named_labels)
-
-    label = last_named_labels.find { |l| l[:ch_index] == ch_index }
+    label   = last_named_labels.find { |l| l[:ch_index] == ch_index }
     scan_status_el[:textContent] = "選局: #{mhz_str} MHz#{label ? " - #{label[:name]}" : ""}"
     pico_client&.write("TUNE:#{freq_hz}\n")
   end
@@ -265,10 +268,7 @@ if directory
     next if hover_ch == last_hover_ch
 
     last_hover_ch = hover_ch
-    renderer.clear
-    renderer.draw_axis
-    renderer.draw_bars(last_rssi_array, selected_ch_index, hover_ch)
-    renderer.draw_station_labels(last_named_labels)
+    refresh_canvas.call
   end
 
   canvas.addEventListener("mouseleave") do |_event|
@@ -276,9 +276,6 @@ if directory
     next if last_rssi_array.nil? || last_named_labels.nil?
 
     last_hover_ch = nil
-    renderer.clear
-    renderer.draw_axis
-    renderer.draw_bars(last_rssi_array, selected_ch_index)
-    renderer.draw_station_labels(last_named_labels)
+    refresh_canvas.call
   end
 end

--- a/web/lib/canvas_renderer.rb
+++ b/web/lib/canvas_renderer.rb
@@ -88,6 +88,11 @@ class CanvasRenderer
     end
   end
 
+  def x_to_ch_index(x)
+    index = (x.to_f / (@width.to_f / @channel_count)).to_i
+    [[index, 0].max, @channel_count - 1].min
+  end
+
   private
 
   LABEL_ROW_COUNT = 2

--- a/web/lib/canvas_renderer.rb
+++ b/web/lib/canvas_renderer.rb
@@ -3,6 +3,7 @@ require "js"
 class CanvasRenderer
   BACKGROUND_COLOR = "#0B1020"
   BAR_COLOR        = "#66CCFF"
+  HOVER_COLOR      = "#CCEEFF"
   CURSOR_COLOR     = "#FFD166"
   AXIS_COLOR       = "#DDDDDD"
   LABEL_BG_COLOR   = "#FFFFFF"
@@ -61,13 +62,19 @@ class CanvasRenderer
     end
   end
 
-  def draw_bars(rssi_array, cursor_index = nil)
+  def draw_bars(rssi_array, cursor_index = nil, hover_index = nil)
     bar_area_h = @height - AXIS_HEIGHT - BAR_BOTTOM_PAD
     rssi_array.each_with_index do |rssi, i|
       x = ch_left_x(i)
       h = (rssi.to_f / 15.0) * bar_area_h
       y = @height - h - BAR_BOTTOM_PAD
-      @ctx[:fillStyle] = (i == cursor_index ? CURSOR_COLOR : BAR_COLOR)
+      @ctx[:fillStyle] = if i == cursor_index
+        CURSOR_COLOR
+      elsif i == hover_index
+        HOVER_COLOR
+      else
+        BAR_COLOR
+      end
       w = [bar_width - 0.6, 1.0].max
       @ctx.call(:fillRect, x, y, w, h)
     end

--- a/web/spec/canvas_renderer_test.rb
+++ b/web/spec/canvas_renderer_test.rb
@@ -1,0 +1,40 @@
+require "minitest/autorun"
+require_relative "../lib/canvas_renderer"
+
+class CanvasRendererTest < Minitest::Test
+  def make_renderer(width: 800, height: 300, channel_count: 191)
+    ctx = Object.new.tap do |obj|
+      obj.define_singleton_method(:[]) { |_k| nil }
+      obj.define_singleton_method(:[]=) { |_k, _v| nil }
+      obj.define_singleton_method(:call) { |*_args| nil }
+    end
+    canvas = Object.new.tap do |obj|
+      obj.define_singleton_method(:[]) { |k| { "width" => width, "height" => height }[k.to_s] }
+      obj.define_singleton_method(:call) { |*_args| ctx }
+    end
+    CanvasRenderer.new(canvas, start_hz: 76_000_000, step_hz: 100_000, channel_count: channel_count)
+  end
+
+  def test_x_to_ch_index_最左端は0
+    assert_equal 0, make_renderer.x_to_ch_index(0)
+  end
+
+  def test_x_to_ch_index_中間値が正しく計算される
+    # ch_index 50 の左端 x = 50 * (800.0 / 191) ≈ 209.42
+    # x = 210 はチャンネル 50 内に収まる
+    assert_equal 50, make_renderer.x_to_ch_index(210)
+  end
+
+  def test_x_to_ch_index_最右バーの範囲内
+    # ch_index 190 の左端 x = 190 * (800.0 / 191) ≈ 795.81
+    assert_equal 190, make_renderer.x_to_ch_index(796)
+  end
+
+  def test_x_to_ch_index_負の座標は0にクランプ
+    assert_equal 0, make_renderer.x_to_ch_index(-10)
+  end
+
+  def test_x_to_ch_index_幅を超えた座標は最大チャンネルにクランプ
+    assert_equal 190, make_renderer.x_to_ch_index(9999)
+  end
+end

--- a/web/spec/canvas_renderer_test.rb
+++ b/web/spec/canvas_renderer_test.rb
@@ -15,6 +15,30 @@ class CanvasRendererTest < Minitest::Test
     CanvasRenderer.new(canvas, start_hz: 76_000_000, step_hz: 100_000, channel_count: channel_count)
   end
 
+  # fillRect 呼び出し時点の fillStyle を記録するスパイ付きレンダラーを返す
+  def make_renderer_with_color_spy(channel_count: 5)
+    colors = []
+    current_fill = nil
+    ctx = Object.new.tap do |obj|
+      obj.define_singleton_method(:[]) { |_k| nil }
+      obj.define_singleton_method(:[]=) do |k, v|
+        current_fill = v if k.to_s == "fillStyle"
+      end
+      obj.define_singleton_method(:call) do |method, *_args|
+        colors << current_fill if method.to_s == "fillRect"
+        nil
+      end
+    end
+    canvas = Object.new.tap do |obj|
+      obj.define_singleton_method(:[]) { |k| { "width" => 800, "height" => 300 }[k.to_s] }
+      obj.define_singleton_method(:call) { |*_args| ctx }
+    end
+    renderer = CanvasRenderer.new(canvas, start_hz: 76_000_000, step_hz: 100_000, channel_count: channel_count)
+    [renderer, colors]
+  end
+
+  # ---- x_to_ch_index ----
+
   def test_x_to_ch_index_最左端は0
     assert_equal 0, make_renderer.x_to_ch_index(0)
   end
@@ -36,5 +60,46 @@ class CanvasRendererTest < Minitest::Test
 
   def test_x_to_ch_index_幅を超えた座標は最大チャンネルにクランプ
     assert_equal 190, make_renderer.x_to_ch_index(9999)
+  end
+
+  # ---- draw_bars の色選択ロジック ----
+
+  def test_draw_bars_通常バーはBAR_COLOR
+    renderer, colors = make_renderer_with_color_spy
+    renderer.draw_bars([5] * 5)
+    assert_equal [CanvasRenderer::BAR_COLOR] * 5, colors
+  end
+
+  def test_draw_bars_cursor_indexのバーはCURSOR_COLOR
+    renderer, colors = make_renderer_with_color_spy
+    renderer.draw_bars([5] * 5, 2)
+    expected = [CanvasRenderer::BAR_COLOR, CanvasRenderer::BAR_COLOR,
+                CanvasRenderer::CURSOR_COLOR,
+                CanvasRenderer::BAR_COLOR, CanvasRenderer::BAR_COLOR]
+    assert_equal expected, colors
+  end
+
+  def test_draw_bars_hover_indexのバーはHOVER_COLOR
+    renderer, colors = make_renderer_with_color_spy
+    renderer.draw_bars([5] * 5, nil, 1)
+    expected = [CanvasRenderer::BAR_COLOR, CanvasRenderer::HOVER_COLOR,
+                CanvasRenderer::BAR_COLOR, CanvasRenderer::BAR_COLOR, CanvasRenderer::BAR_COLOR]
+    assert_equal expected, colors
+  end
+
+  def test_draw_bars_cursor_indexとhover_indexが重なった場合はCURSOR_COLORが優先
+    renderer, colors = make_renderer_with_color_spy
+    renderer.draw_bars([5] * 5, 3, 3)
+    expected = [CanvasRenderer::BAR_COLOR, CanvasRenderer::BAR_COLOR,
+                CanvasRenderer::BAR_COLOR, CanvasRenderer::CURSOR_COLOR, CanvasRenderer::BAR_COLOR]
+    assert_equal expected, colors
+  end
+
+  def test_draw_bars_cursor_indexとhover_indexが別々に設定される
+    renderer, colors = make_renderer_with_color_spy
+    renderer.draw_bars([5] * 5, 1, 3)
+    expected = [CanvasRenderer::BAR_COLOR, CanvasRenderer::CURSOR_COLOR,
+                CanvasRenderer::BAR_COLOR, CanvasRenderer::HOVER_COLOR, CanvasRenderer::BAR_COLOR]
+    assert_equal expected, colors
   end
 end

--- a/web/spec/js.rb
+++ b/web/spec/js.rb
@@ -1,0 +1,2 @@
+module JS
+end


### PR DESCRIPTION
## セルフレビュー実施済み

セルフコードレビューを実施し，medium 指摘（クロージャ変数キャプチャのバグ）を push 前に修正しました．

---

## Summary

- スキャン完了後，スペクトルグラフの周波数バーをクリックするとその周波数を固定受信できるようにした
- スキャン中はクリックを無視（スキャン最優先）
- スキャン前（バー未描画）もクリックを無視

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `web/lib/canvas_renderer.rb` | `x_to_ch_index(x)` 公開メソッドを追加（Canvas X 座標 → チャンネルインデックス変換） |
| `web/app.rb` | `is_scanning` フラグ・`last_rssi_array` / `last_named_labels` 変数を追加．canvas click ハンドラを実装 |
| `firmware/app.rb` | `TUNE:<freq_hz>` コマンド対応を追加（SCAN/TUNE を case/when で分岐） |
| `web/spec/canvas_renderer_test.rb` | `x_to_ch_index` の単体テストを追加（TDD） |
| `web/spec/js.rb` | テスト環境向け `js` モジュールスタブを追加 |

## 実装の注意点

### クロージャ変数キャプチャ

`last_rssi_array` / `last_named_labels` を `finalize_scan` lambda **より前** で宣言することで，クロージャに確実にキャプチャさせています．Ruby では，lambda 定義時点で外側スコープに存在しない変数への代入は lambda ローカル変数になるため，宣言順が重要です．

### CSS スケーリング補正

canvas の CSS `width: 100%; max-width: 800px;` により，画面幅が 800px 未満のときにクリック座標のずれが生じます．`getBoundingClientRect().width` から `scale` を算出してクリック座標を補正しています．

### PicoRuby 制約（firmware）

`rescue` が未サポートのため，TUNE コマンド解析は `split(":")` + `nil?` チェック + 範囲チェックで防御しています．

## Test plan

- [ ] モックスキャン前にグラフクリック → `scan_status_el` 変化なしを確認
- [ ] モックスキャン中にグラフクリック → バー移動なし・ステータス変化なしを確認
- [ ] モックスキャン完了後にバークリック → 黄色ハイライト移動・"選局: XX.X MHz" 表示を確認
- [ ] ウィンドウ幅 800px 未満で縮小してクリック → CSS スケーリング補正が機能することを確認
- [ ] 再スキャン後に別のバーをクリック → 新スキャン結果でクリックが動作することを確認
- [ ] `web/rake test` が 77 件全通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)