### PR TITLE
feat: 受信停止ボタンを追加する

### DIFF
--- a/firmware/app.rb
+++ b/firmware/app.rb
@@ -75,5 +75,10 @@ loop do
     led.write(1)
     sleep_ms(50)
     led.write(0)
+  when "MUTE"
+    receiver.mute
+    led.write(1)
+    sleep_ms(50)
+    led.write(0)
   end
 end

--- a/firmware/lib/tea5767.rb
+++ b/firmware/lib/tea5767.rb
@@ -27,6 +27,10 @@ class TEA5767
     )
   end
 
+  def mute
+    @i2c.write(ADDRESS, 0x80, 0x00, 0b1011_0000, 0b0001_0000, 0b0000_0000)
+  end
+
   def status
     res = @i2c.read(ADDRESS, 5)
     return { ready: false, stereo: false, rssi: 0 } if res.to_s.length < 5

--- a/firmware/lib/tea5767.rb
+++ b/firmware/lib/tea5767.rb
@@ -12,23 +12,33 @@ class TEA5767
   end
 
   def initialize(i2c)
-    @i2c = i2c
+    @i2c      = i2c
+    @last_pll = self.class.pll_for(76_000_000)  # 初期値: バンド最低周波数
   end
 
   def tune(freq_hz)
-    pll = self.class.pll_for(freq_hz)
+    @last_pll = self.class.pll_for(freq_hz)
     @i2c.write(
       ADDRESS,
-      (pll >> 8) & 0x3F,   # MUTE=0, SM=0, PLL[13:8]
-      pll & 0xFF,           # PLL[7:0]
-      0b1011_0000,          # SUD=1, SSL=01, HLSI=1, MS=0
-      0b0001_0000,          # XTAL=1
-      0b0000_0000,          # PLLREF=0, DTC=0 (50 μs)
+      (@last_pll >> 8) & 0x3F,   # MUTE=0, SM=0, PLL[13:8]
+      @last_pll & 0xFF,            # PLL[7:0]
+      0b1011_0000,                 # SUD=1, SSL=01, HLSI=1, MS=0
+      0b0001_0000,                 # XTAL=1
+      0b0000_0000,                 # PLLREF=0, DTC=0 (50 μs)
     )
   end
 
+  # MUTE ビットを立てつつ最後の PLL 値を保持する．
+  # PLL=0 を送ると TEA5767 が異常状態になるため @last_pll を使う．
   def mute
-    @i2c.write(ADDRESS, 0x80, 0x00, 0b1011_0000, 0b0001_0000, 0b0000_0000)
+    @i2c.write(
+      ADDRESS,
+      ((@last_pll >> 8) & 0x3F) | 0x80,   # MUTE=1, PLL[13:8]
+      @last_pll & 0xFF,                     # PLL[7:0]
+      0b1011_0000,                          # SUD=1, SSL=01, HLSI=1, MS=0
+      0b0001_0000,                          # XTAL=1
+      0b0000_0000,                          # PLLREF=0, DTC=0 (50 μs)
+    )
   end
 
   def status

--- a/web/app.rb
+++ b/web/app.rb
@@ -124,6 +124,7 @@ if directory
     start_mock_btn[:disabled]   = true
     connect_pico_btn[:disabled] = true
     scan_pico_btn[:disabled]    = true
+    stop_btn[:disabled]         = true
     pico_client&.close
     pico_client = nil
 
@@ -176,9 +177,11 @@ if directory
     on_stream_end = lambda do |message|
       next unless pico_client.equal?(client)
       scan_status_el[:textContent] = "Pico 切断: #{message}"
+      is_scanning                  = false
       connect_pico_btn[:disabled]  = false
       start_mock_btn[:disabled]    = false
       scan_pico_btn[:disabled]     = true
+      stop_btn[:disabled]          = true
       current_handler              = nil
       client.close
       pico_client = nil
@@ -213,6 +216,7 @@ if directory
 
     is_scanning                  = true
     scan_pico_btn[:disabled]     = true
+    stop_btn[:disabled]          = true
     scan_status_el[:textContent] = "スキャン中..."
     peak_tbody_el[:innerHTML]    = "<tr><td colspan=\"3\">スキャン中...</td></tr>"
 

--- a/web/app.rb
+++ b/web/app.rb
@@ -17,6 +17,7 @@ start_mock_btn   = document.getElementById("start-mock")
 connect_pico_btn = document.getElementById("connect-pico")
 scan_status_el   = document.getElementById("scan-status")
 scan_pico_btn    = document.getElementById("scan-pico")
+stop_btn         = document.getElementById("stop-btn")
 peak_tbody_el    = document.getElementById("peak-tbody")
 region_select_el = document.getElementById("region")
 
@@ -50,6 +51,7 @@ if directory
   status_el[:className]   = "status ok"
 
   is_scanning        = false
+  is_stopped         = false
   last_rssi_array    = nil
   last_named_labels  = nil
   selected_ch_index  = nil
@@ -70,8 +72,10 @@ if directory
       }
     end
 
-    selected_ch_index = nil
-    last_hover_ch     = nil
+    selected_ch_index  = nil
+    last_hover_ch      = nil
+    is_stopped         = false
+    stop_btn[:disabled] = true
     renderer.clear
     renderer.draw_axis
     renderer.draw_bars(rssi_array)
@@ -237,6 +241,14 @@ if directory
     renderer.draw_station_labels(last_named_labels)
   end
 
+  stop_btn.addEventListener("click") do
+    next if stop_btn[:disabled].to_s == "true"
+    is_stopped          = true
+    stop_btn[:disabled] = true
+    scan_status_el[:textContent] = "受信停止中"
+    pico_client&.write("MUTE\n")
+  end
+
   canvas.addEventListener("click") do |event|
     next if is_scanning
     next if last_rssi_array.nil? || last_named_labels.nil?
@@ -246,7 +258,9 @@ if directory
     canvas_x = (event[:clientX].to_f - rect[:left].to_f) * scale
     ch_index = renderer.x_to_ch_index(canvas_x)
 
-    selected_ch_index = ch_index
+    selected_ch_index  = ch_index
+    is_stopped         = false
+    stop_btn[:disabled] = pico_client ? false : true
     refresh_canvas.call
 
     freq_hz = START_HZ + STEP_HZ * ch_index

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,7 @@
       <button type="button" id="start-mock">モックスキャン開始</button>
       <button type="button" id="connect-pico">Pico に接続</button>
       <button type="button" id="scan-pico" disabled>スキャン実行</button>
+      <button type="button" id="stop-btn" disabled>受信停止</button>
       <span id="scan-status">待機中</span>
     </p>
   </section>


### PR DESCRIPTION
## セルフレビュー実施済み

セルフレビューで medium 指摘 1 件（`pico_client.nil?` の DOM 代入一貫性）を修正済み。

## 概要

- 選局後に「受信停止」ボタンが有効になり、押下すると TEA5767 の MUTE ビットをセットして無音化する
- 再開はバーをクリックすることで TUNE コマンドを再送し受信を再開する
- Pico 未接続（モックスキャン）時は停止ボタンを無効のままにする

## 変更内容

- `web/index.html`: 受信停止ボタン（`stop-btn`）を追加
- `web/app.rb`: `is_stopped` 状態変数・停止ハンドラ・click ハンドラ更新
- `firmware/lib/tea5767.rb`: `mute` メソッドを追加（MUTE ビット=1 の固定バイト列を I2C 送信）
- `firmware/app.rb`: `when "MUTE"` ケースを追加

## テスト

既存 `spec/canvas_renderer_test.rb` 10 件すべてパス（回帰なし）。

Closes #35