### PR TITLE
feat: Web UI の表示改善と地域変更時の局名自動更新

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -87,7 +87,7 @@ if directory
     scan_status_el[:textContent] = "完了 (#{named.size} 局検出)"
   end
 
-  finalize_scan = lambda do |aggregator, region_key|
+  finalize_scan = lambda do |aggregator|
     rssi_array = aggregator.pixels
     peaks      = PeakDetector.detect(rssi_array, threshold: PEAK_THRESHOLD)
     last_peaks = peaks.map do |peak|
@@ -100,10 +100,10 @@ if directory
     is_stopped          = false
     stop_btn[:disabled] = true
     last_rssi_array     = rssi_array
-    relabel.call(region_key)
+    relabel.call(region_select_el[:value].to_s)
   end
 
-  make_handler = lambda do |aggregator, region_key, on_finish|
+  make_handler = lambda do |aggregator, on_finish|
     lambda do |msg|
       case msg["t"]
       when "tick"
@@ -114,7 +114,7 @@ if directory
         renderer.draw_bars(aggregator.pixels, msg["i"])
         scan_status_el[:textContent] = "スキャン中: #{msg["i"] + 1}/#{CHANNEL_COUNT} ch"
       when "done"
-        finalize_scan.call(aggregator, region_key)
+        finalize_scan.call(aggregator)
         on_finish&.call
       when "error"
         scan_status_el[:textContent] = "受信エラー: #{msg["msg"]}"
@@ -162,7 +162,7 @@ if directory
       start_mock_btn[:disabled]    = false
       connect_pico_btn[:disabled]  = false
     end
-    stream.run(&make_handler.call(aggregator, region_key, on_finish))
+    stream.run(&make_handler.call(aggregator, on_finish))
   rescue => e
     scan_status_el[:textContent] = "スキャン準備エラー: #{e.message}"
     is_scanning                  = false
@@ -232,7 +232,6 @@ if directory
     scan_status_el[:textContent] = "スキャン中..."
     peak_tbody_el[:innerHTML]    = "<tr><td colspan=\"3\">スキャン中...</td></tr>"
 
-    region_key = region_select_el[:value].to_s
     aggregator = Aggregator.new(channel_count: CHANNEL_COUNT, pixel_count: CHANNEL_COUNT)
 
     on_scan_done = lambda do
@@ -241,7 +240,7 @@ if directory
       current_handler          = nil
     end
 
-    current_handler = make_handler.call(aggregator, region_key, on_scan_done)
+    current_handler = make_handler.call(aggregator, on_scan_done)
     pico_client.write("SCAN\n")   # コマンド名は firmware/app.rb の line.strip == "SCAN" と対応
   rescue => e
     scan_status_el[:textContent] = "スキャン準備エラー: #{e.message}"
@@ -251,6 +250,7 @@ if directory
   end
 
   region_select_el.addEventListener("change") do
+    next if is_scanning
     relabel.call(region_select_el[:value].to_s)
   end
 

--- a/web/app.rb
+++ b/web/app.rb
@@ -54,41 +54,53 @@ if directory
   is_stopped         = false
   last_rssi_array    = nil
   last_named_labels  = nil
+  last_peaks         = nil
   selected_ch_index  = nil
   last_hover_ch      = nil
 
-  finalize_scan = lambda do |aggregator, region_key|
-    rssi_array = aggregator.pixels
-    peaks = PeakDetector.detect(rssi_array, threshold: PEAK_THRESHOLD)
-    named = peaks.map do |peak|
-      freq_hz = START_HZ + STEP_HZ * peak[:i]
-      station = directory.lookup(region_key, freq_hz)
+  refresh_canvas = lambda do
+    renderer.clear
+    renderer.draw_axis
+    renderer.draw_bars(last_rssi_array, selected_ch_index, last_hover_ch)
+    renderer.draw_station_labels(last_named_labels)
+  end
+
+  relabel = lambda do |region_key|
+    return if last_peaks.nil?
+    named = last_peaks.map do |peak|
+      station = directory.lookup(region_key, peak[:freq_hz])
       {
-        ch_index: peak[:i],
-        freq_hz:  freq_hz,
+        ch_index: peak[:ch_index],
+        freq_hz:  peak[:freq_hz],
         rssi:     peak[:rssi],
         name:     station ? station["name"] : "(未登録)",
         kind:     station ? station["kind"] : nil,
       }
     end
-
-    selected_ch_index  = nil
-    last_hover_ch      = nil
-    is_stopped         = false
-    stop_btn[:disabled] = true
-    renderer.clear
-    renderer.draw_axis
-    renderer.draw_bars(rssi_array)
-    last_rssi_array   = rssi_array
     last_named_labels = named.map { |p| { ch_index: p[:ch_index], name: p[:name] } }
-    renderer.draw_station_labels(last_named_labels)
-
+    refresh_canvas.call
     rows = named.sort_by { |p| -p[:rssi] }.map do |p|
       mhz = format("%.1f", p[:freq_hz] / 1_000_000.0)
       "<tr><td>#{mhz} MHz</td><td>#{p[:rssi]}/15</td><td>#{html_escape(p[:name])}</td></tr>"
     end.join
     peak_tbody_el[:innerHTML] = rows.empty? ? "<tr><td colspan=\"3\">検出なし</td></tr>" : rows
     scan_status_el[:textContent] = "完了 (#{named.size} 局検出)"
+  end
+
+  finalize_scan = lambda do |aggregator, region_key|
+    rssi_array = aggregator.pixels
+    peaks      = PeakDetector.detect(rssi_array, threshold: PEAK_THRESHOLD)
+    last_peaks = peaks.map do |peak|
+      freq_hz = START_HZ + STEP_HZ * peak[:i]
+      { ch_index: peak[:i], freq_hz: freq_hz, rssi: peak[:rssi] }
+    end
+
+    selected_ch_index   = nil
+    last_hover_ch       = nil
+    is_stopped          = false
+    stop_btn[:disabled] = true
+    last_rssi_array     = rssi_array
+    relabel.call(region_key)
   end
 
   make_handler = lambda do |aggregator, region_key, on_finish|
@@ -238,11 +250,8 @@ if directory
     current_handler              = nil
   end
 
-  refresh_canvas = lambda do
-    renderer.clear
-    renderer.draw_axis
-    renderer.draw_bars(last_rssi_array, selected_ch_index, last_hover_ch)
-    renderer.draw_station_labels(last_named_labels)
+  region_select_el.addEventListener("change") do
+    relabel.call(region_select_el[:value].to_s)
   end
 
   stop_btn.addEventListener("click") do

--- a/web/assets/style.css
+++ b/web/assets/style.css
@@ -123,6 +123,7 @@ button:disabled {
   color: var(--muted);
   font-family: "Consolas", "SF Mono", monospace;
   font-size: 0.9rem;
+  margin: 0.5rem 0 0;
 }
 
 #peak-table {
@@ -144,6 +145,36 @@ button:disabled {
 
 #peak-table tbody tr:nth-child(even) {
   background: #FAFAFA;
+}
+
+.rssi-guide-label {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 1.5rem 0 0.25rem;
+}
+
+.rssi-guide {
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.rssi-guide th,
+.rssi-guide td {
+  padding: 0.3rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  color: var(--muted);
+}
+
+.rssi-guide th {
+  background: #F5F5F5;
+  font-weight: bold;
+}
+
+.rssi-note {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0.5rem 0 0;
 }
 
 footer {

--- a/web/index.html
+++ b/web/index.html
@@ -30,8 +30,8 @@
       <button type="button" id="connect-pico">Pico に接続</button>
       <button type="button" id="scan-pico" disabled>スキャン実行</button>
       <button type="button" id="stop-btn" disabled>受信停止</button>
-      <span id="scan-status">待機中</span>
     </p>
+    <p id="scan-status">待機中</p>
   </section>
 
   <section id="spectrum-section">
@@ -49,6 +49,20 @@
         <tr><td colspan="3">スキャン未実行</td></tr>
       </tbody>
     </table>
+    <p class="rssi-guide-label">RSSI 目安表（参考値）</p>
+    <table class="rssi-guide">
+      <thead>
+        <tr><th>RSSI</th><th>目安 (dBµV)</th><th>受信状況</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>0</td><td>9.5</td><td>ほぼ無信号</td></tr>
+        <tr><td>4</td><td>21.5</td><td>弱</td></tr>
+        <tr><td>8</td><td>33.5</td><td>中</td></tr>
+        <tr><td>11</td><td>42.5</td><td>良好</td></tr>
+        <tr><td>15</td><td>54.5</td><td>非常に良好</td></tr>
+      </tbody>
+    </table>
+    <p class="rssi-note">TEA5767 の設計値（9.5〜54.5 dBµV，3.0 dB 刻み）を基にした概算値．正確な RF dBµV 計測値ではない．<a href="https://www.rockbox.org/tracker/8151" target="_blank" rel="noopener">参照: Rockbox FS#8151</a></p>
   </section>
 
   <section id="status-section">


### PR DESCRIPTION
## 概要

Web UI の使い勝手に関する 3 件の改善をまとめて対応する．

- RSSI 目安表の追加と参照リンクの掲載
- スキャンステータス表示のレイアウト改善
- 地域変更時の局名ラベル自動更新（再スキャン不要化）

## 変更内容

### RSSI 目安表の追加

検出局テーブルの下に TEA5767 の RSSI 値（0〜15）と受信強度目安（dBµV）の対応表を追加した．
TEA5767 の設計値（9.5〜54.5 dBµV，3.0 dB 刻み）を基にした概算値であり，正確な RF 計測値ではない．
参照元として Rockbox FS#8151 へのリンクを掲載した．

### ステータス表示の独立行化

スキャン状態を示す `#scan-status` をボタン行の `<p class="controls">` 外に移動し，
独立した `<p>` 要素として左寄せで表示するよう変更した．

### 地域変更時の局名自動更新

従来はスキャン後に地域を変更しても局名が更新されず，再スキャンが必要だった．

- スキャン結果の生ピークデータ（周波数・RSSI）を `last_peaks` に保持する
- `relabel` lambda で地域キーを受け取り局名を引き直す
- `region_select` の `change` イベントで `relabel` を呼ぶことで再スキャン不要にした
- `refresh_canvas` を `relabel` より前に定義することで Ruby.wasm のクロージャキャプチャ問題を回避した

## テスト計画

- [ ] モックスキャン後に地域を切り替え，スペクトラムのラベルと検出局テーブルが即時更新されることを確認する
- [ ] Pico スキャン後も同様に地域切り替えが動作することを確認する
- [ ] スキャン前に地域を変更しても何も起きない（エラーなし）ことを確認する
- [ ] RSSI 目安表が検出局テーブルの下に正しく表示されることを確認する
- [ ] ステータス表示がボタン行の下に独立して表示されることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)