### PR TITLE
feat: 野幌（江別市）の局データを stations.json に追加する

### DIFF
--- a/web/data/stations.json
+++ b/web/data/stations.json
@@ -160,6 +160,68 @@
         }
       ]
     },
+    "nopporo": {
+      "name": "野幌（江別市）",
+      "prefecture": "北海道",
+      "stations": [
+        {
+          "freq_khz": 76500,
+          "name": "FMアップル（エフエムとよひら）",
+          "kind": "community",
+          "power_w": 20,
+          "site": "札幌市豊平区",
+          "note": "JOZZ1AJ-FM．放送エリアに江別市を含む"
+        },
+        {
+          "freq_khz": 77600,
+          "name": "FMドラマシティ（Radio YAMASHO）",
+          "kind": "community",
+          "power_w": 20,
+          "site": "札幌市厚別区",
+          "note": "JOZZ1AQ-FM．野幌周辺（場所による）で受信可"
+        },
+        {
+          "freq_khz": 80400,
+          "name": "AIR-G'（FM 北海道）",
+          "kind": "fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "FM 北海道 札幌局"
+        },
+        {
+          "freq_khz": 82500,
+          "name": "FM NORTH WAVE",
+          "kind": "fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "FM ノースウェーブ 札幌局"
+        },
+        {
+          "freq_khz": 85200,
+          "name": "NHK-FM 札幌",
+          "kind": "fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "JOAS-FM"
+        },
+        {
+          "freq_khz": 90400,
+          "name": "STV ラジオ（ワイドFM）",
+          "kind": "wide_fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "STV ラジオ FM 補完放送"
+        },
+        {
+          "freq_khz": 91500,
+          "name": "HBC ラジオ（ワイドFM）",
+          "kind": "wide_fm",
+          "power_w": 5000,
+          "site": "札幌（手稲山）",
+          "note": "HBC ラジオ FM 補完放送"
+        }
+      ]
+    },
     "tokyo": {
       "name": "東京（23 区）",
       "prefecture": "東京都",


### PR DESCRIPTION
## セルフレビュー実施済み

## 概要

江別市野幌でのデモに向け，`nopporo` リージョンを新設して 7 局を登録した．

- 手稲山からの主要 FM 5 局（AIR-G', FM NORTH WAVE, NHK-FM 札幌, STV ワイドFM, HBC ワイドFM）
- 放送エリアに江別市を含むコミュニティ FM 2 局
  - FMアップル（JOZZ1AJ-FM）76.5 MHz／豊平区 20 W
  - FMドラマシティ（JOZZ1AQ-FM）77.6 MHz／厚別区 20 W（野幌周辺・場所による）

## 変更ファイル

- `web/data/stations.json`：`nopporo` リージョン追加（7 局）

## テスト

- `ruby spec/station_directory_test.rb` 22 runs, 147 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)