### PR TITLE
feat: 地域ドロップダウンを stations.json から動的生成する

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -50,6 +50,13 @@ if directory
   status_el[:textContent] = "Ruby.wasm 起動成功: Ruby #{RUBY_VERSION}"
   status_el[:className]   = "status ok"
 
+  directory.regions.each do |key|
+    opt = document.call(:createElement, "option")
+    opt[:value]       = key
+    opt[:textContent] = directory.region_name(key)
+    region_select_el.call(:appendChild, opt)
+  end
+
   is_scanning        = false
   is_stopped         = false
   last_rssi_array    = nil

--- a/web/app.rb
+++ b/web/app.rb
@@ -53,7 +53,7 @@ if directory
   directory.regions.each do |key|
     opt = document.call(:createElement, "option")
     opt[:value]       = key
-    opt[:textContent] = directory.region_name(key)
+    opt[:textContent] = directory.region_name(key) || key
     region_select_el.call(:appendChild, opt)
   end
 

--- a/web/index.html
+++ b/web/index.html
@@ -18,13 +18,7 @@
     <p class="controls">
       <label>
         地域:
-        <select id="region">
-          <option value="hakodate">函館市</option>
-          <option value="asahikawa">旭川市</option>
-          <option value="sapporo">札幌市</option>
-          <option value="kitami">北見市</option>
-          <option value="tokyo">東京（23 区）</option>
-        </select>
+        <select id="region"></select>
       </label>
       <button type="button" id="start-mock">モックスキャン開始</button>
       <button type="button" id="connect-pico">Pico に接続</button>

--- a/web/lib/station_directory.rb
+++ b/web/lib/station_directory.rb
@@ -9,6 +9,10 @@ class StationDirectory
     @data.fetch("regions").keys
   end
 
+  def region_name(region_key)
+    @data.dig("regions", region_key, "name")
+  end
+
   def stations(region_key)
     @data.dig("regions", region_key, "stations") || []
   end

--- a/web/spec/station_directory_test.rb
+++ b/web/spec/station_directory_test.rb
@@ -70,6 +70,16 @@ class StationDirectoryTest < Minitest::Test
     dir = StationDirectory.new(FIXTURE)
     assert_nil dir.lookup("sapporo", 80_700_000)
   end
+
+  def test_region_nameはキーに対応する表示名を返す
+    dir = StationDirectory.new(FIXTURE)
+    assert_equal "函館市", dir.region_name("hakodate")
+  end
+
+  def test_存在しないキーのregion_nameはnil
+    dir = StationDirectory.new(FIXTURE)
+    assert_nil dir.region_name("unknown")
+  end
 end
 
 class StationDirectoryDataTest < Minitest::Test


### PR DESCRIPTION
## セルフレビュー実施済み

## 概要

`index.html` のハードコード `<option>` を廃止し，`app.rb` 起動時に
`StationDirectory#regions` / `#region_name` を使ってドロップダウンを動的に構築する．
これにより `stations.json` にリージョンを追加するだけで UI へ自動的に反映される．

## 変更ファイル

- `web/lib/station_directory.rb`：`region_name(key)` メソッドを追加
- `web/spec/station_directory_test.rb`：`region_name` の正常系・異常系テストを追加
- `web/app.rb`：`directory` 確定後にドロップダウンを動的生成するコードを追加
- `web/index.html`：ハードコードの `<option>` 要素を削除

## テスト

- `ruby spec/station_directory_test.rb` 24 runs, 149 assertions, 0 failures

## セルフレビュー懸念

- low: `region_name` が `nil` を返した場合に option 表示名が空になる可能性がある．`stations.json` は静的ファイルかつ全リージョンに `name` が必ず存在するため，このブランチのスコープでは許容する．

🤖 Generated with [Claude Code](https://claude.com/claude-code)